### PR TITLE
Causing error with yaml load

### DIFF
--- a/wallboard-import.py
+++ b/wallboard-import.py
@@ -234,7 +234,7 @@ if len(sys.argv) != 2:
 
 with open(sys.argv[1]) as Input:
     try:
-        Config = yaml.load(Input)
+        Config = yaml.safe_load(Input)
     except yaml.YAMLError as e:
         print(e)
         sys.exit(1)


### PR DESCRIPTION
You get this error when using yaml.load()
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(open(config))
change to yaml.safe_load to make it run

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
